### PR TITLE
Fix hyphen variable name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import find_packages, setup
 from typing import List 
-hypen_e = '-e .'
+hyphen_e = '-e .'
 def remove_hyphen_e(requirements: List[str]) -> List[str]:
     """
     This function removes the '-e .' entry from the requirements list.
     """
-    if hypen_e in requirements:
-        requirements.remove(hypen_e)
+    if hyphen_e in requirements:
+        requirements.remove(hyphen_e)
     return requirements
 
 def get_requirements(file_path: str) -> List[str]:


### PR DESCRIPTION
## Summary
- fix a typo in `setup.py`

## Testing
- `python setup.py --version`


------
https://chatgpt.com/codex/tasks/task_e_684605b68f5c8329a2aa8e628c793493