### PR TITLE
Fix CustomException __str__

### DIFF
--- a/src/exception.py
+++ b/src/exception.py
@@ -29,4 +29,4 @@ class CustomException(Exception):
         self.error = error
         self.detail = detail
     def __str__(self):
-        return self.error_message_detail(self.error, self.detail)
+        return error_message_detail(self.error, self.detail)


### PR DESCRIPTION
## Summary
- fix bug in `CustomException.__str__`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -e .`
- `python - <<'PY'
from src.exception import CustomException
try:
    raise ValueError('test')
except Exception as e:
    ce = CustomException(e, __import__('sys'))
    print(str(ce))
PY`


------
https://chatgpt.com/codex/tasks/task_e_684604ce01a88329a7d10939506fc14f